### PR TITLE
Change Char to String

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,6 @@ jobs:
         npm install
         spago install
     - name: Build
-      run: npm run build
+      run: spago build
     - name: Test
-      run: npm test
+      run: spago test --no-install

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -25,6 +25,6 @@ bower install
 ## Publish
 
 ```sh
-git tag v0.2.0
+git tag v0.3.0
 pulp publish --no-push
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,7 +34,7 @@ Add the following lines in `packages.dhall`.
   with qieyun =
     { dependencies = [ "effect", "nullable", "psci-support" ]
     , repo = "https://github.com/nk2028/purescript-qieyun.git"
-    , version = "v0.2.0"
+    , version = "v0.3.0"
     }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,5 @@
 {
   "private": true,
-  "scripts": {
-    "build": "spago build",
-    "test": "spago test --no-install"
-  },
   "dependencies": {
     "qieyun": "^0.11.0"
   }

--- a/src/Qieyun.purs
+++ b/src/Qieyun.purs
@@ -202,36 +202,36 @@ foreign import fromPhonologicalEncoding :: String -> PhonologicalLocation
 
 -- Queries
 
-foreign import representativeCharacter1 :: PhonologicalLocation -> Nullable Char
+foreign import representativeCharacter1 :: PhonologicalLocation -> Nullable String
 
 -- | Get the representative character (代表字) of a phonological location (音韻地位).
 -- |
 -- | ```purescript
--- | representativeCharacter $ fromPhonologicalDescription "幫三凡入" = Just '法'
--- | representativeCharacter $ fromPhonologicalDescription "羣開三A支平" = Just '祇'
+-- | representativeCharacter $ fromPhonologicalDescription "幫三凡入" = Just "法"
+-- | representativeCharacter $ fromPhonologicalDescription "羣開三A支平" = Just "祇"
 -- | representativeCharacter $ fromPhonologicalDescription "常開三麻去" = Nothing
 -- | ```
-representativeCharacter ::  PhonologicalLocation -> Maybe Char
+representativeCharacter ::  PhonologicalLocation -> Maybe String
 representativeCharacter pl = toMaybe $ representativeCharacter1 pl
 
-foreign import fanqie1 :: Char -> PhonologicalLocation -> Nullable String
+foreign import fanqie1 :: String -> PhonologicalLocation -> Nullable String
 
 -- | Get the fanqie (反切) of a phonological location (音韻地位).
 -- |
 -- | ```purescript
--- | fanqie '法' $ fromPhonologicalDescription "幫三凡入" = Just '方乏'
--- | fanqie '祇' $ fromPhonologicalDescription "羣開三A支平" = Just '巨支'
+-- | fanqie "法" $ fromPhonologicalDescription "幫三凡入" = Just "方乏"
+-- | fanqie "祇" $ fromPhonologicalDescription "羣開三A支平" = Just "巨支"
 -- | ```
 -- |
 -- | If you want to get the default fanqie of a phonological location, you can provide some random characters
--- | as the first parameter, such as `'?'`.
+-- | as the first parameter, such as `"?"`.
 -- |
 -- | ```purescript
--- | fanqie '?' $ fromPhonologicalDescription "幫三凡入" = Just '方乏'
--- | fanqie '?' $ fromPhonologicalDescription "羣開三A支平" = Just '巨支'
--- | fanqie '?' $ fromPhonologicalDescription "常開三麻去" = Nothing
+-- | fanqie "?" $ fromPhonologicalDescription "幫三凡入" = Just "方乏"
+-- | fanqie "?" $ fromPhonologicalDescription "羣開三A支平" = Just "巨支"
+-- | fanqie "?" $ fromPhonologicalDescription "常開三麻去" = Nothing
 -- | ```
-fanqie :: Char -> PhonologicalLocation -> Maybe String
+fanqie :: String -> PhonologicalLocation -> Maybe String
 fanqie ch pl = toMaybe $ fanqie1 ch pl
 
 -- | Get the corresponding characters and their explanations of a phonological location (音韻地位).
@@ -245,9 +245,9 @@ foreign import entries :: PhonologicalLocation -> Array { character :: String, e
 -- | Get the explanations and phonological locations (音韻地位) of a character.
 -- |
 -- | ```purescript
--- | queryCharacter '結' = [{ explanation: "締也古屑切十五", phonologicalLocation: #見開四先入 }]
+-- | queryCharacter "結" = [{ explanation: "締也古屑切十五", phonologicalLocation: #見開四先入 }]
 -- | ```
-foreign import queryCharacter :: Char -> Array { explanation :: String, phonologicalLocation :: PhonologicalLocation }
+foreign import queryCharacter :: String -> Array { explanation :: String, phonologicalLocation :: PhonologicalLocation }
 
 -- List all phonological locations
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -23,6 +23,7 @@ import Qieyun
   , phonologicalExpression
   , satisfies
   -- Constructor
+  , phonologicalLocation
   , fromPhonologicalDescription
   , fromPhonologicalEncoding
   -- Queries
@@ -35,7 +36,7 @@ foreign import exit :: String -> Effect Unit
 shouldEqual :: forall a. Show a => Eq a => a -> a -> Effect Unit
 shouldEqual a b =
   if a /= b
-    then exit $ (show a) <> " should be equal to " <> (show b)
+    then exit $ show a <> " should be equal to " <> show b
     else pure unit
 
 x :: PhonologicalLocation
@@ -60,12 +61,11 @@ main = do
   phonologicalEncoding pl `shouldEqual` "A5T"
   phonologicalExpression pl `shouldEqual` "幫母 三等 凡韻 入聲"
 
-  representativeCharacter pl `shouldEqual` Just '法'
-  fanqie '法' pl `shouldEqual` Just "方乏"
+  representativeCharacter pl `shouldEqual` Just "法"
+  fanqie "法" pl `shouldEqual` Just "方乏"
 
   satisfies pl "脣音" `shouldEqual` true
   satisfies pl "三等 平聲" `shouldEqual` false
 
-  let pl2 = fromPhonologicalEncoding "A5T"
-
-  pl `shouldEqual` pl2
+  pl `shouldEqual` fromPhonologicalEncoding "A5T"
+  pl `shouldEqual` phonologicalLocation "幫" Nothing "三" Nothing "凡" "入"


### PR DESCRIPTION
Since `Char` represents a UTF-16 code unit instead of a code point, it cannot properly handle Chinese characters like `"𦫖"`. See <https://github.com/purescript/purescript/issues/3662>.